### PR TITLE
Add new style: Linguistics Vanguard

### DIFF
--- a/linguistics-vanguard.csl
+++ b/linguistics-vanguard.csl
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize-with-hyphen="false" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Linguistics Vanguard</title>
+    <title-short>LingVan</title-short>
+    <id>http://www.zotero.org/styles/linguistics-vanguard</id>
+    <link href="http://www.zotero.org/styles/linguistics-vanguard" rel="self"/>
+    <link href="http://www.zotero.org/styles/journal-of-historical-linguistics" rel="template"/>
+    <link href="https://www.degruyterbrill.com/journal/key/lingvan/html#submit" rel="documentation"/>
+    <author>
+      <name>Tsy Yih</name>
+      <email>yihtsy@outlook.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="linguistics"/>
+    <eissn>2199-174X</eissn>
+    <updated>2025-09-17T12:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="by">ed. by</term>
+    </terms>
+  </locale>
+  <macro name="editor-translator">
+    <names variable="editor translator" prefix="(" suffix=")" delimiter=", ">
+      <name and="text" initialize-with="" delimiter=", "/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter-precedes-last="never" initialize="false" initialize-with="." name-as-sort-order="first" and="symbol"/>
+      <et-al font-style="normal"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short"/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <citation collapse="year-suffix" and="text" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter=",">
+    <sort>
+      <key variable="issued"/>
+      <key variable="author"/>
+    </sort>
+    <layout delimiter=", " prefix="(" suffix=")">
+      <group>
+        <text macro="author-short" text-case="capitalize-first" suffix=" "/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <group prefix=": ">
+          <text variable="locator" prefix=" "/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false">
+    <sort>
+      <key macro="author-short"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="author" text-case="capitalize-first" suffix="."/>
+      <date variable="issued" text-case="uppercase" prefix=" " suffix=".">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" In " suffix=".">
+            <names variable="editor"> 
+              <name initialize="false" and="symbol" delimiter=", " delimiter-precedes-last="never" />
+              <label form="short" prefix=" (" suffix=")"/>
+            </names>
+            <text variable="container-title" font-style="italic" prefix=", "/>
+            <text variable="page" prefix=", " />
+            <text macro="publisher" prefix=". "/>
+          </group>
+        </else-if>
+        <else-if type="thesis" match="any">
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <text prefix=" Unpublished thesis, " suffix="." variable="publisher"/>
+        </else-if>
+        <else>
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <group delimiter="" prefix=" " suffix=".">
+              <text variable="volume"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
+            <text variable="page" prefix=" "/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This commit adds a new CSL style for the journal *Linguistics Vanguard*.

- Based on the Journal of Historical Linguistics template.
- Adapted according to the official author guidelines of the journal.
- Validated with the CSL validator (https://validator.citationstyles.org/).

Please let me know if further adjustments are needed.